### PR TITLE
feat : 로그인 토큰 관리 기능 추가

### DIFF
--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -20,7 +20,8 @@ import {
   EmailInput,
   EmailDomain,
 } from '../styles/pages/Loginpage';
-import axios from 'axios';
+import axiosInstance from '../utils/axiosConfig';
+import { setTokens } from '../utils/tokenUtils';
 
 const LoginPage = () => {
   const navigate = useNavigate();
@@ -36,32 +37,15 @@ const LoginPage = () => {
         password: password
       };
 
-      // console.log('로그인 요청:', {
-      //   url: `${process.env.REACT_APP_API_URL}/users/login/`,
-      //   data: requestData
-      // });
-
-      const response = await axios.post(
-        `${process.env.REACT_APP_API_URL}/users/login/`,
-        requestData,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-          }
-        }
-      );
-
-      // console.log('로그인 응답:', response);
+      const response = await axiosInstance.post('/users/login/', requestData);
 
       if (response.data.code === 200) {
-        localStorage.setItem('access_token', response.data.data.access);
-        localStorage.setItem('refresh_token', response.data.data.refresh);
+        setTokens(response.data.data.access, response.data.data.refresh);
         navigate('/');
       } else {
         setError(true);
       }
     } catch (error) {
-      // console.error('로그인 에러:', error.response || error);
       setError(true);
     }
   };

--- a/src/utils/axiosConfig.js
+++ b/src/utils/axiosConfig.js
@@ -1,0 +1,51 @@
+import axios from 'axios';
+import { getAccessToken, getRefreshToken, setTokens, removeTokens } from './tokenUtils';
+
+const axiosInstance = axios.create({
+  baseURL: process.env.REACT_APP_API_URL,
+});
+
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const token = getAccessToken();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        const refreshToken = getRefreshToken();
+        const response = await axios.post(
+          `${process.env.REACT_APP_API_URL}/users/token/refresh/`,
+          { refresh: refreshToken }
+        );
+
+        const { access } = response.data;
+        setTokens(access, refreshToken);
+        
+        originalRequest.headers.Authorization = `Bearer ${access}`;
+        return axiosInstance(originalRequest);
+      } catch (error) {
+        removeTokens();
+        window.location.href = '/login';
+        return Promise.reject(error);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default axiosInstance; 

--- a/src/utils/tokenUtils.js
+++ b/src/utils/tokenUtils.js
@@ -1,0 +1,21 @@
+export const setTokens = (accessToken, refreshToken) => {
+  localStorage.setItem('access_token', accessToken);
+  localStorage.setItem('refresh_token', refreshToken);
+};
+
+export const getAccessToken = () => {
+  return localStorage.getItem('access_token');
+};
+
+export const getRefreshToken = () => {
+  return localStorage.getItem('refresh_token');
+};
+
+export const removeTokens = () => {
+  localStorage.removeItem('access_token');
+  localStorage.removeItem('refresh_token');
+};
+
+export const isAuthenticated = () => {
+  return !!getAccessToken();
+}; 


### PR DESCRIPTION
### 사용 가이드

1. API 요청 시 토큰 사용하기:

```jsx
import axiosInstance from '../utils/axiosConfig';

// API 요청 예시
const fetchData = async () => {
  try {
    const response = await axiosInstance.get('/some-endpoint/');
    // 처리 로직
  } catch (error) {
    // 에러 처리
  }
};

```

2. 인증 상태 확인하기:

```jsx
import { isAuthenticated } from '../utils/tokenUtils';

const MyComponent = () => {
  useEffect(() => {
    if (!isAuthenticated()) {
      navigate('/login');
    }
  }, []);
  // ...
};

```